### PR TITLE
Exclude the HTML placeholder attribute

### DIFF
--- a/src/Middleware/TrimUrls.php
+++ b/src/Middleware/TrimUrls.php
@@ -7,8 +7,7 @@ class TrimUrls extends PageSpeed
     public function apply($buffer)
     {
         $replace = [
-            '/https:/' => '',
-            '/http:/' => ''
+            '/(?<!placeholder=")https?:/' => ''
         ];
 
         return $this->replace($replace, $buffer);

--- a/tests/Boilerplate/index.html
+++ b/tests/Boilerplate/index.html
@@ -35,6 +35,7 @@
             <input type="text" disabled="true" value="teste" width="100%">
             <input type="text" disabled="true">
             <input style="border:1px solid red" type="text" disabled=true>
+            <input placeholder="https://example.com/">
 
             <select style="height:300px; padding:10px">
                 <option selected="selected" class="selected" style="cursor: default">Item</option>

--- a/tests/Middleware/TrimUrlsTest.php
+++ b/tests/Middleware/TrimUrlsTest.php
@@ -16,8 +16,11 @@ class TrimUrlsTest extends TestCase
     {
         $response = $this->middleware->handle($this->request, $this->getNext());
 
-        $this->assertNotContains("https://", $response->getContent());
-        $this->assertNotContains("http://", $response->getContent());
-        $this->assertContains("//code.jquery.com/jquery-3.2.1.min.js", $response->getContent());
+        $this->assertNotContains('href=https://', $response->getContent());
+        $this->assertNotContains('href=http://', $response->getContent());
+        $this->assertNotContains('src=https://', $response->getContent());
+        $this->assertNotContains('src=http://', $response->getContent());
+        $this->assertContains('placeholder="https://example.com/"', $response->getContent());
+        $this->assertContains('//code.jquery.com/jquery-3.2.1.min.js', $response->getContent());
     }
 }


### PR DESCRIPTION
## Description

`TrimUrls` has been fixed.

## Motivation and context

In the placeholder http and https should not be removed.

## How has this been tested?

`composer test`

The test `testTrimUrls` is fixed and expanded.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.